### PR TITLE
chore(deps): declare ESM module type in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "lab",
+  "type": "module",
   "private": true,
   "packageManager": "pnpm@11.4.0",
   "description": "Experimental prototypes.",

--- a/packages/vue-challenges/package.json
+++ b/packages/vue-challenges/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@lab/vue-challenges",
+  "type": "module",
   "version": "3.3.0",
   "private": true,
   "description": "Collection of Vue.js challenges",

--- a/packages/vue-design/package.json
+++ b/packages/vue-design/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@lab/vue-design",
+  "type": "module",
   "version": "3.3.0",
   "private": true,
   "engines": {

--- a/packages/vue-trello/package.json
+++ b/packages/vue-trello/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@lab/vue-trello",
+  "type": "module",
   "version": "3.3.0",
   "private": true,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Add `"type": "module"` to root `package.json` and Vue packages (`vue-challenges`, `vue-design`, `vue-trello`) to explicitly declare ESM module resolution

## Test Plan

- [x] `pnpm build` passes successfully